### PR TITLE
Change domCheck to work in server rendering

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var canUseDOM = require('can-use-dom');
-var enquire = canUseDOM && require('enquire.js');
+var enquire = require('enquire.js');
 var json2mq = require('json2mq');
 
 var ResponsiveMixin = {
@@ -10,7 +10,7 @@ var ResponsiveMixin = {
         match: handler
       };
     }
-    enquire.register(query, handler);
+    canUseDOM && enquire.register(query, handler);
 
     // Queue the handlers to unregister them at unmount  
     if (! this._responsiveMediaHandlers) {
@@ -21,7 +21,7 @@ var ResponsiveMixin = {
   componentWillUnmount: function () {
     if (this._responsiveMediaHandlers) {
       this._responsiveMediaHandlers.forEach(function(obj) {
-        enquire.unregister(obj.query, obj.handler);
+        canUseDOM && enquire.unregister(obj.query, obj.handler);
       });
     }
   }


### PR DESCRIPTION
This changes allow to use server rendering properly, avoinding errors like this:

```
→ gatsby build
Generating CSS
Generating Static HTML
Failed at generating HTML

/home/renato/Projects/landing/node_modules/gatsby/dist/bin/cli.js:52
      throw err;
      ^
Error: TypeError: enquire.register is not a function
```

**Additional information:**
https://github.com/gatsbyjs/gatsby/issues/410#issuecomment-243607426
